### PR TITLE
Wire inputs to calculation logic and show basic results

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,21 @@
 import { Header } from '@/components/Header'
 import { NumberInput } from '@/components/NumberInput'
 import { RegionSelector } from '@/components/RegionSelector'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { RegionCode } from '@/types'
+import { calculate, formatCurrency, formatPercent } from './utils/calculator'
 
 function App() {
   const [quantity, setQuantity] = useState('')
   const [price, setPrice] = useState('')
   const [region, setRegion] = useState<RegionCode | null>(null)
+
+  const result = useMemo(() => {
+    const qty = Number(quantity)
+    const _price = Number(price)
+    if (!qty || !_price || !region || qty <= 0 || _price <= 0) return null
+    return calculate(qty, _price, region)
+  }, [quantity, price, region])
 
   return (
     <>
@@ -22,6 +30,36 @@ function App() {
                 <NumberInput id="price" label="Price per item" value={price} onChange={setPrice} prefix="$" />
               </div>
               <RegionSelector value={region} onChange={setRegion} />
+            </div>
+
+            {/* Results */}
+            <div className="h-36">
+              {result ? (
+                <div className="font-mono text-sm space-y-2 mb-5">
+                  <div className="flex justify-between">
+                    <span className="text-stone-500">
+                      Subtotal ({quantity} × ${Number(price).toFixed(2)})
+                    </span>
+                    <span>{formatCurrency(result.subtotal)}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-stone-500">Discount</span>
+                    <span className="text-lime-400">− {formatCurrency(result.discountAmount)}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-stone-500">
+                      {region} Tax ({formatPercent(result.taxRate)})
+                    </span>
+                    <span className="text-yellow-300">+ {formatCurrency(result.taxAmount)}</span>
+                  </div>
+                  <div className="flex justify-between pt-2 border-t border-stone-800">
+                    <span className="text-stone-400 text-xs uppercase tracking-widest">Total (NZD)</span>
+                    <span className="text-lime-400 text-2xl">{formatCurrency(result.total)}</span>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-center text-stone-600 text-sm py-4 mb-5">Fill in all fields to see the breakdown</p>
+              )}
             </div>
           </div>
         </div>

--- a/src/utils/calculator.ts
+++ b/src/utils/calculator.ts
@@ -31,3 +31,11 @@ export function calculate(quantity: number, pricePerItem: number, region: Region
 export function formatPercent(rate: number): string {
   return `${(rate * 100).toFixed(2)}%`
 }
+
+export function formatCurrency(value: number): string {
+  return new Intl.NumberFormat('en-NZ', {
+    style: 'currency',
+    currency: 'NZD',
+    minimumFractionDigits: 2,
+  }).format(value)
+}


### PR DESCRIPTION
Closes #7 

## What's in this PR
- Wired quantity, price, and region inputs to calculate()
- Result computed with useMemo
- Results section showing subtotal, discount, tax, and total

## Notes
- `formatCurrency` utility fn added to show formatted currencies in the results section
